### PR TITLE
Avgprice/add avgprice

### DIFF
--- a/binance/client.py
+++ b/binance/client.py
@@ -923,6 +923,27 @@ class Client:
             d[sp['symbol']] = float(sp['price'])
         return d
 
+    def avgPrice(self, **params):
+        """Average price information for a symbol. 
+
+        https://github.com/binance-exchange/binance-official-api-docs
+        /blob/master/rest-api.md#current-average-price
+
+        :param symbol:
+        :type symbol: str
+
+        :returns: API response
+
+        .. code-block:: python
+
+            {'mins': 5, 'price': '3452.789282'} 
+
+        :raises: ResponseException, APIException, ConnectionError
+
+        """
+        return self._get('avgPrice', data=params,
+                version=self.PRIVATE_API_VERSION)
+
     def orderbook_ticker(self, **params):
         """Latest price for a symbol or symbols.
 


### PR DESCRIPTION
Binance have recently updated the API, see: 

https://support.binance.com/hc/en-us/articles/360019518392-Updates-to-Binance-API-Trading-Rules

I needed to be able to use the 'average price for last 5 minutes' endpoint of the API, see:

https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#current-average-price

so I have added this functionality to the Client class. I am an amateur at git and contributing in this way, so I hope I have done everything correctly.